### PR TITLE
Cleanup binstub for rubocop

### DIFF
--- a/lib/spring/client/binstub.rb
+++ b/lib/spring/client/binstub.rb
@@ -34,7 +34,8 @@ unless defined?(Spring)
   require 'bundler'
 
   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
-  if spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  if spring
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
     gem 'spring', spring.version
     require 'spring/binstub'


### PR DESCRIPTION
Rubocop considers the following line in a client's `bin/spring` file to be a possible error:

```ruby
if spring = lockfile.specs.detect { |spec| spec.name == "spring" }
```

Rubocop assumes most people are going to use a comparison `==` in an `if` statement, so it flags the use of `=` as a potential error.

Suggest we clean this up so Rubocop users stop seeing the warning in their output.